### PR TITLE
Please add syntax for infix-doller-reader

### DIFF
--- a/cl-syntax-infix-doller.asd
+++ b/cl-syntax-infix-doller.asd
@@ -1,0 +1,13 @@
+(in-package :cl-user)
+
+(defpackage :cl-syntax-infix-doller-asd
+  (:use :cl :asdf))
+(in-package :cl-syntax-infix-doller-asd)
+
+(defsystem :cl-syntax-infix-doller
+  :version "0.1"
+  :author "Shingo SUZUKI"
+  :license "LLGPL"
+  :description "CL-Syntax Reader Syntax for infix-doller-reader"
+  :depends-on (:cl-syntax :infix-doller-reader)
+  :components ((:file "contrib/infix-doller")))

--- a/contrib/infix-doller.lisp
+++ b/contrib/infix-doller.lisp
@@ -1,0 +1,5 @@
+(in-package :cl-user)
+
+(syntax:define-package-syntax :infix-doller
+  (:merge :standard)
+  (:macro-char #\$ #'infix-doller-reader::infix-doller-reader) )


### PR DESCRIPTION
I've send an issue to Quicklisp project to register infix-doller-reader.
https://github.com/ichimal/infix-doller-reader
https://github.com/quicklisp/quicklisp-projects/issues/364

If this issue-to-register is accepted, please pull this commit.
### usage:

```
(asdf:load-system :cl-syntax-infix-doller)
(cl-syntax:use-syntax :infix-doller) ; and also :idoller or :infix-doller-reader
(=  (+ 1 2 $ * 3 4 $ + 5 6) (+ 1 2 (* 3 4 (+ 5 6)))) ; => t
```
