### PR TITLE
Fix %use-syntax to work for values other than package designators.

### DIFF
--- a/src/operators.lisp
+++ b/src/operators.lisp
@@ -16,7 +16,7 @@
 (defmacro defsyntax (name &body options)
   `(progn
      (setf (get ',name :options) ',options)
-     (defreadtable ,name ,@options)))
+     (defvar ,name (defreadtable ,name ,@options))))
 
 (defmacro define-package-syntax (&body (package . options))
   (unless (typep package 'package-designator)


### PR DESCRIPTION
Fixes #10
